### PR TITLE
Set an empty cookie when forgetting the session

### DIFF
--- a/pyramid_authsanity/sources.py
+++ b/pyramid_authsanity/sources.py
@@ -96,6 +96,6 @@ def CookieAuthSourceInitializer(
             return self.cookie.get_headers(value, domains=self.domains)
 
         def headers_forget(self):
-            return self.cookie.get_headers('', max_age=0)
+            return self.cookie.get_headers(None, max_age=0)
 
     return CookieAuthSource

--- a/pyramid_authsanity/tests/test_sources.py
+++ b/pyramid_authsanity/tests/test_sources.py
@@ -109,8 +109,9 @@ class TestCookieAuthSource(_TestAuthSource):
 
         assert isinstance(headers, Iterable)
 
+        # Should set an empty cookie
         for h in headers:
-            assert 'auth' in h[1]
+            assert h[1].startswith("auth=;")
 
     def test_get_value_cookie(self):
         request = DummyRequest()
@@ -123,6 +124,14 @@ class TestCookieAuthSource(_TestAuthSource):
     def test_get_value_bad_cookie(self):
         request = DummyRequest()
         request.cookies['auth'] = "jxxxxxxxfFFc3Qcx5O84h4u8NSZIi51xVMYs_HyP94BO1aXGZpME_LJ1UZgfdAMJDoaGaLCt_y-x6FSBh3ZKDyJ0ZXN0Ig"
+        source = self._makeOne(request=request)
+        val = source.get_value()
+
+        assert val == [None, None]
+
+    def test_get_value_empty_cookie(self):
+        request = DummyRequest()
+        request.cookies['auth'] = ""
         source = self._makeOne(request=request)
         val = source.get_value()
 


### PR DESCRIPTION
This PR fixes a bug where under certain circumstances a correctly signed cookie containing an empty string value was deserialized by `CookieAuthSource.get_value()`, resulting in a ValueError being thrown by the auth policy.

The root of the problem is that CookieAuthSource.headers_forget() returns the result of

```python
self.cookie.get_headers('', max_age=0)
```

which resulted in a cookie being set which contained a correctly signed empty string value:

     In [1]: from pyramid_authsanity.sources import CookieAuthSourceInitializer

     In [2]: source_ctor = CookieAuthSourceInitializer('mysecretvalue')

     In [3]: source = source_ctor(context=None, request=request)

     In [4]: source.headers_forget()
     Out[4]:
     [('Set-Cookie',
       'auth=JwjVGt<...>MryIi; Max-Age=0; Path=/; expires=Fri, 10-Mar-2017 13:53:42 GMT')]

In theory, this shouldn't cause any problems, because the cookie is also set with a zero "Max-Age", which should cause the cookie to be immediately deleted and never used again. Unfortunately [certain browsers][1] don't respect Max-Age, and so a client with an unsynchronised local clock can end up sending this cookie back to the server.

[1]: https://balanceiskey.github.io/2015/11/25/ie11-cookies.html

The fix is relatively straightforward. Supplying `None` as the value for the cookie [correctly short-circuits the cookie serializer][2], ensures that the resulting cookie is empty and has an expiry date in the distant past:

     In [5]: source.cookie.get_headers(None)
     Out[5]:
     [('Set-Cookie',
       'auth=; Max-Age=0; Path=/; expires=Wed, 31-Dec-97 23:59:59 GMT')]

[2]: https://github.com/Pylons/webob/blob/0ea393f347e5bcce5582800b29f939c9512f6cc0/webob/cookies.py#L733-L735