### PR TITLE
Add Authorization header based source

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+parallel = true
+source =
+    pyramid_authsanity
+    tests
+omit =
+
+[paths]
+source =
+    src/pyramid_authsanity
+    */site-packages/pyramid_authsanity
+
+[report]
+show_missing = true
+precision = 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,10 +49,10 @@ test:3.6:
 
 test:pep8:
     <<: *test
-    image: python:3.5
+    image: python:3.6
     script:
         - pip install tox
-        - TOXENV=pep8 tox
+        - TOXENV=lint tox
 
 test_cov:
     <<: *test
@@ -65,10 +65,10 @@ test_cov:
         - apt-get upgrade -y
         - apt-get install -y python3.5 python2.7 python-pip
         - pip install tox
-        - TOXENV=py2-cover,py3-cover,coverage tox
+        - TOXENV=py27,py35,coverage tox
 
 pages:
-    image: python:3.5
+    image: python:3.6
     script:
         - apt-get install make
         - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ matrix:
         - python: 3.6
         - python: pypy
           env: TOXENV=pypy
-        - python: 3.5
-          env: TOXENV=py2-cover,py3-cover,coverage
-        - python: 3.5
-          env: TOXENV=pep8
+        - python: 3.6
+          env: TOXENV=py27,py36,coverage
+        - python: 3.6
+          env: TOXENV=lint
         - python: nightly
           env: TOXENV=py37
     allow_failures:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,12 @@
+graft src
+graft tests
+graft docs
+
 include README.rst
 include CHANGES.rst
 include LICENSE
+
+include .coveragerc
+include tox.ini .travis.yml rtd.txt .gitlab-ci.yml
+
+recursive-exclude * __pycache__ *.py[cod]

--- a/docs/api/sources.rst
+++ b/docs/api/sources.rst
@@ -13,3 +13,7 @@ Cookie Authentication Source
 
 .. autofunction:: CookieAuthSourceInitializer
 
+Authorization Header Authentication Source
+------------------------------------------
+
+.. autofunction:: HeaderAuthSourceInitializer

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,11 @@ exclude = pyramid_authsanity/tests/
 show-source = True
 max-line-length = 89
 
+[check-manifest]
+ignore =
+    .gitignore
+    PKG-INFO
+    *.egg-info
+    *.egg-info/*
+ignore-default-rules = true
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ universal = 1
 license_file = LICENSE
 
 [flake8]
-ignore = E301,E302,E731,E261,E123,E121,E128,E129,E125,W291,E501,W293,E303,W391,E266,E231,E201,E202,E127,E262,E265
 exclude = pyramid_authsanity/tests/
 show-source = True
+max-line-length = 89
 

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,6 @@ requires = [
 
 tests_require = requires + [
     'pytest',
-]
-
-coverage_require = tests_require + [
     'coverage',
     'pytest-cov',
     ]
@@ -58,7 +55,6 @@ setup(
     install_requires=requires,
     extras_require={
         'testing': tests_require,
-        'coverage': coverage_require,
         'docs': docs_require,
     },
     entry_points={

--- a/src/pyramid_authsanity/__init__.py
+++ b/src/pyramid_authsanity/__init__.py
@@ -12,8 +12,9 @@ from .policy import (
     )
 
 from .sources import (
-    SessionAuthSourceInitializer,
     CookieAuthSourceInitializer,
+    HeaderAuthSourceInitializer,
+    SessionAuthSourceInitializer,
     )
 
 from .util import (
@@ -44,11 +45,27 @@ def init_session_source(config, settings):
     kw = kw_from_settings(settings, 'authsanity.session.')
 
     config.register_service_factory(SessionAuthSourceInitializer(**kw), iface=IAuthSourceService)
+def init_authorization_header_source(config, settings):
+    if 'authsanity.secret' not in settings:
+        raise RuntimeError(
+            'authsanity.secret is required for Authorization header source'
+        )
+
+    kw = kw_from_settings(settings, 'authsanity.header.')
+
+    config.register_service_factory(
+        HeaderAuthSourceInitializer(
+            settings['authsanity.secret'],
+            **kw
+        ),
+        iface=IAuthSourceService
+    )
 
 
 default_sources = {
     'cookie': init_cookie_source,
     'session': init_session_source,
+    'header': init_authorization_header_source,
 }
 
 # Stolen from pyramid_debugtoolbar

--- a/src/pyramid_authsanity/__init__.py
+++ b/src/pyramid_authsanity/__init__.py
@@ -33,18 +33,31 @@ default_settings = (
     ('session.value_key', str, 'sanity.'),
 )
 
+
 def init_cookie_source(config, settings):
     if 'authsanity.secret' not in settings:
         raise RuntimeError('authsanity.secret is required for cookie based storage')
 
     kw = kw_from_settings(settings, 'authsanity.cookie.')
 
-    config.register_service_factory(CookieAuthSourceInitializer(settings['authsanity.secret'], **kw), iface=IAuthSourceService)
+    config.register_service_factory(
+        CookieAuthSourceInitializer(
+            settings['authsanity.secret'],
+            **kw
+        ),
+        iface=IAuthSourceService
+    )
+
 
 def init_session_source(config, settings):
     kw = kw_from_settings(settings, 'authsanity.session.')
 
-    config.register_service_factory(SessionAuthSourceInitializer(**kw), iface=IAuthSourceService)
+    config.register_service_factory(
+        SessionAuthSourceInitializer(**kw),
+        iface=IAuthSourceService
+    )
+
+
 def init_authorization_header_source(config, settings):
     if 'authsanity.secret' not in settings:
         raise RuntimeError(
@@ -67,6 +80,7 @@ default_sources = {
     'session': init_session_source,
     'header': init_authorization_header_source,
 }
+
 
 # Stolen from pyramid_debugtoolbar
 def parse_settings(settings):

--- a/src/pyramid_authsanity/interfaces.py
+++ b/src/pyramid_authsanity/interfaces.py
@@ -3,6 +3,7 @@ from zope.interface import (
     Interface,
     )
 
+
 class IAuthSourceService(Interface):
     """ Represents an authentication source. """
 
@@ -19,6 +20,7 @@ class IAuthSourceService(Interface):
     def headers_forget():
         """ Returns any and all headers for forgetting the current requests
         value. """
+
 
 class IAuthService(Interface):
     """ Represents an authentication service. This service verifies that the

--- a/src/pyramid_authsanity/policy.py
+++ b/src/pyramid_authsanity/policy.py
@@ -19,6 +19,7 @@ from .util import (
 
 from zope.interface import implementer
 
+
 def _clean_principal(princid):
     """ Utility function that cleans up the passed in principal
     This can easily also be extended for example to make sure that certain
@@ -42,8 +43,8 @@ class AuthServicePolicy(object):
             methodname = classname + '.' + methodname
             logger.debug(methodname + ': ' + msg)
 
-    _find_services = staticmethod(_find_services) # Testing
-    _session_registered = staticmethod(_session_registered) # Testing
+    _find_services = staticmethod(_find_services)  # Testing
+    _session_registered = staticmethod(_session_registered)  # Testing
     _have_session = _marker
 
     def __init__(self, debug=False):
@@ -61,9 +62,12 @@ class AuthServicePolicy(object):
 
         try:
             userid = authsvc.userid()
-        except:
-            debug and self._log('authentication has not yet been completed',
-                    'authenticated_userid', request)
+        except Exception:
+            debug and self._log(
+                'authentication has not yet been completed',
+                'authenticated_userid',
+                request
+            )
             (principal, ticket) = sourcesvc.get_value()
 
             debug and self._log(
@@ -76,11 +80,14 @@ class AuthServicePolicy(object):
             try:
                 # This should now return None or the userid
                 userid = authsvc.userid()
-            except:
+            except Exception:
                 userid = None
 
-        debug and self._log('authenticated_userid returning: %r' % (userid,),
-                'authenticated_userid', request)
+        debug and self._log(
+            'authenticated_userid returning: %r' % (userid,),
+            'authenticated_userid',
+            request
+        )
 
         return userid
 
@@ -137,9 +144,19 @@ class AuthServicePolicy(object):
 
         value = {}
         value['principal'] = principal
-        value['ticket'] = ticket = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode('ascii')
+        value['ticket'] = ticket = (
+            base64.urlsafe_b64encode(
+                os.urandom(32)
+            ).
+            rstrip(b"=").
+            decode('ascii')
+        )
 
-        debug and self._log('Remember principal: %r, ticket: %r' % (principal, ticket), 'remember', request)
+        debug and self._log(
+            'Remember principal: %r, ticket: %r' % (principal, ticket),
+            'remember',
+            request
+        )
 
         authsvc.add_ticket(principal, ticket)
 

--- a/src/pyramid_authsanity/sources.py
+++ b/src/pyramid_authsanity/sources.py
@@ -1,3 +1,5 @@
+from pyramid.compat import native_
+
 from webob.cookies import (
     JSONSerializer,
     SignedCookieProfile,
@@ -109,6 +111,8 @@ def HeaderAuthSourceInitializer(
     secret,
     salt='sanity.header.'
 ):
+    """ An authentication source that uses the Authorization header. """
+
     @implementer(IAuthSourceService)
     class HeaderAuthSource(object):
         vary = ['Authorization']
@@ -149,7 +153,7 @@ def HeaderAuthSourceInitializer(
                 self.cur_val = None
 
             token = self._create_authorization(value)
-            auth_info = str(b'Bearer ' + token, 'latin-1', 'strict')
+            auth_info = native_(b'Bearer ' + token, 'latin-1', 'strict')
             return [('Authorization', auth_info)]
 
         def headers_forget(self):

--- a/src/pyramid_authsanity/sources.py
+++ b/src/pyramid_authsanity/sources.py
@@ -1,14 +1,18 @@
 from webob.cookies import (
+    JSONSerializer,
     SignedCookieProfile,
-    )
+    SignedSerializer,
+)
 
 from zope.interface import implementer
 
 from .interfaces import (
     IAuthSourceService,
-    )
+)
 
-def SessionAuthSourceInitializer(value_key='sanity.'):
+def SessionAuthSourceInitializer(
+    value_key='sanity.'
+):
     """ An authentication source that uses the current session """
 
     value_key = value_key + 'value'
@@ -56,7 +60,7 @@ def CookieAuthSourceInitializer(
     domains=None,
     debug=False,
     hashalg='sha512',
-    ):
+):
     """ An authentication source that uses a unique cookie. """
 
     @implementer(IAuthSourceService)
@@ -99,3 +103,59 @@ def CookieAuthSourceInitializer(
             return self.cookie.get_headers(None, max_age=0)
 
     return CookieAuthSource
+
+
+def HeaderAuthSourceInitializer(
+    secret,
+    salt='sanity.header.'
+):
+    @implementer(IAuthSourceService)
+    class HeaderAuthSource(object):
+        vary = ['Authorization']
+
+        def __init__(self, context, request):
+            self.request = request
+            self.cur_val = None
+
+            serializer = JSONSerializer()
+            self.serializer = SignedSerializer(
+                secret,
+                salt,
+                serializer=serializer,
+                )
+
+        def _get_authorization(self):
+            try:
+                type, token = self.request.authorization
+
+                return self.serializer.loads(token)
+            except Exception:
+                return None
+
+        def _create_authorization(self, value):
+            try:
+                return self.serializer.dumps(value)
+            except Exception:
+                return ''
+
+        def get_value(self):
+            if self.cur_val is None:
+                self.cur_val = self._get_authorization() or [None, None]
+
+            return self.cur_val
+
+        def headers_remember(self, value):
+            if self.cur_val is None:
+                self.cur_val = None
+
+            token = self._create_authorization(value)
+            auth_info = str(b'Bearer ' + token, 'latin-1', 'strict')
+            return [('Authorization', auth_info)]
+
+        def headers_forget(self):
+            if self.cur_val is None:
+                self.cur_val = None
+
+            return []
+
+    return HeaderAuthSource

--- a/src/pyramid_authsanity/sources.py
+++ b/src/pyramid_authsanity/sources.py
@@ -12,6 +12,7 @@ from .interfaces import (
     IAuthSourceService,
 )
 
+
 def SessionAuthSourceInitializer(
     value_key='sanity.'
 ):

--- a/src/pyramid_authsanity/util.py
+++ b/src/pyramid_authsanity/util.py
@@ -7,11 +7,18 @@ from .interfaces import (
     IAuthSourceService,
     )
 
+
 def int_or_none(x):
     return int(x) if x is not None else x
 
+
 def kw_from_settings(settings, from_prefix='authsanity.'):
-    return { k.replace(from_prefix, ''): v for k, v in settings.items() if k.startswith(from_prefix) }
+    return {
+        k.replace(from_prefix, ''): v
+        for k, v in settings.items()
+        if k.startswith(from_prefix)
+    }
+
 
 def add_vary_callback(vary_by):
     def vary_add(request, response):
@@ -20,11 +27,13 @@ def add_vary_callback(vary_by):
         response.vary = list(vary)
     return vary_add
 
+
 def _find_services(request):
     sourcesvc = request.find_service(IAuthSourceService)
     authsvc = request.find_service(IAuthService)
 
     return (sourcesvc, authsvc)
+
 
 def _session_registered(request):
     registry = request.registry

--- a/tests/test_includeme.py
+++ b/tests/test_includeme.py
@@ -69,3 +69,22 @@ class TestAuthServicePolicyIntegration(object):
         assert isinstance(auth_policy['policy'], AuthServicePolicy)
         assert verifyClass(IAuthSourceService, find_service_factory(
             self.config, IAuthSourceService))
+
+    def test_include_me_header_with_secret(self):
+        from pyramid_authsanity.policy import AuthServicePolicy
+        settings = {'authsanity.source': 'header', 'authsanity.secret': 'sekrit'}
+
+        self._makeOne(settings)
+        self.config.commit()
+        introspector = self.config.registry.introspector
+        auth_policy = introspector.get('authentication policy', None)
+
+        assert isinstance(auth_policy['policy'], AuthServicePolicy)
+        assert verifyClass(IAuthSourceService, find_service_factory(
+            self.config, IAuthSourceService))
+
+    def test_include_me_header_no_secret(self):
+        settings = {'authsanity.source': 'header'}
+
+        with pytest.raises(RuntimeError):
+            self._makeOne(settings)

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -52,7 +52,7 @@ class TestSessionAuthSource(_TestAuthSource):
         request = DummyRequest()
         request.session['sanity.value'] = "test"
         source = self._makeOne(request=request)
-        headers = source.headers_forget()
+        source.headers_forget()
 
         assert 'sanity.value' not in request.session
 
@@ -96,12 +96,14 @@ class TestCookieAuthSource(_TestAuthSource):
         for h in headers:
             assert 'auth' in h[1]
 
-    @pytest.mark.skipif(sys.version_info < (3,0),
-                    reason="json.dumps() doesn't like binary data on Python 3.x")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 0),
+        reason="json.dumps() doesn't like binary data on Python 3.x"
+    )
     def test_get_header_remember_binary(self):
         source = self._makeOne()
         with pytest.raises(TypeError):
-            headers = source.headers_remember(b"test")
+            source.headers_remember(b"test")
 
     def test_get_header_forget(self):
         source = self._makeOne()

--- a/tox.ini
+++ b/tox.ini
@@ -1,67 +1,55 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,pypy,pypy3,pep8,docs,
-    {py2,py3}-cover,coverage
-skip_missing_interpreters = True
+    lint,
+    py27,py34,py35,py36,pypy,
+    docs,coverage
 
 [testenv]
-# Most of these are defaults but if you specify any you can't fall back
-# to defaults for others.
 basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6
-    py37: python3.7
     pypy: pypy
-    pypy3: pypy3
     py2: python2.7
-    py3: python3.4
-    docs: python3.5
+    py3: python3.6
+    pypy3: pypy3
 
 commands =
     pip install pyramid_authsanity[testing]
-    py.test --junitxml=pytest-{envname}.xml {posargs:}
+    py.test --cov --cov-report= {posargs:}
 
-[py-cover]
-commands =
-    pip install pyramid_authsanity[coverage]
-    py.test --cov-report term-missing --cov=pyramid_authsanity
-
-[testenv:py2-cover]
-commands =
-    {[py-cover]commands}
 setenv =
-    COVERAGE_FILE=.coverage.py2
-
-[testenv:py3-cover]
-commands =
-    {[py-cover]commands}
-setenv =
-    COVERAGE_FILE=.coverage.py3
+    COVERAGE_FILE=.coverage.{envname}
 
 [testenv:coverage]
-basepython = python3.5
+skip_install = True
+basepython = python3.6
 commands =
-    coverage erase
     coverage combine
-    coverage xml
-    coverage report --show-missing --fail-under=100
+    coverage report --fail-under=100
 deps =
     coverage
 setenv =
     COVERAGE_FILE=.coverage
 
 [testenv:docs]
-whitelist_externals = make
+basepython = python3.6
+whitelist_externals =
+    make
 commands =
     pip install pyramid_authsanity[docs]
-    make -C docs html epub BUILDDIR={envdir} "SPHINXOPTS=-W -E"
+    make -C docs html BUILDDIR={envdir} SPHINXOPTS="-W -E"
 
-[testenv:pep8]
-basepython = python3.5
+[testenv:lint]
+skip_install = True
+basepython = python3.6
 commands =
-    flake8 pyramid_authsanity/
+    flake8 src/pyramid_authsanity/
+    python setup.py check -r -s -m
+    check-manifest
 deps =
     flake8
+    readme_renderer
+    check-manifest
 


### PR DESCRIPTION
Adds a new source that reads the Authorization header from the request.

Tests are forthcoming. When the authentication is successful an `Authorization: Bearer <token>` header is set on the response that the client should grab and re-use in future requests.