### PR TITLE
Do not invalidate session if prev_userid == None

### DIFF
--- a/src/pyramid_authsanity/policy.py
+++ b/src/pyramid_authsanity/policy.py
@@ -161,7 +161,7 @@ class AuthServicePolicy(object):
         authsvc.add_ticket(principal, ticket)
 
         # Clear the previous session
-        if self._have_session:
+        if prev_userid is not None and self._have_session:
             if prev_userid != principal:
                 request.session.invalidate()
             else:


### PR DESCRIPTION
Applications might use the session to carry information from the unauthenticated to the authenticated request.

Currently, pyramid_authsanity clears the session when the user signs in. This makes the session unusable for carrying information from the unauthenticated to the authenticated request.

This fix preserves the session when the user is signing in from an unauthenticated request.

@bertjwregeer @stevepiercy 