### PR TITLE
docs: fix simple typo, authenitcation -> authentication

### DIFF
--- a/docs/narr/policy.rst
+++ b/docs/narr/policy.rst
@@ -2,7 +2,7 @@ The authentication policy
 =========================
 
 This authentication policy has two moving pieces, they work together to provide
-an easy to use authenitcation policy that provides more security by allowing
+an easy to use authentication policy that provides more security by allowing
 the server to terminate an active authentication session.
 
 Source Service


### PR DESCRIPTION
There is a small typo in docs/narr/policy.rst.

Should read `authentication` rather than `authenitcation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md